### PR TITLE
Sort numerically not alphabetically

### DIFF
--- a/projects/ng-sortgrid/src/lib/sort/reflection/ngsg-reflect.service.ts
+++ b/projects/ng-sortgrid/src/lib/sort/reflection/ngsg-reflect.service.ts
@@ -15,7 +15,9 @@ export class NgsgReflectService {
     const selectedElements = this.ngsgStore.getSelectedItems(key);
     const selectedElementIndices = this.getSelectedElementsIndices(selectedElements);
     const selectedItems = this.getSelectedItems(items, selectedElementIndices);
-    const sortedIndices = selectedElementIndices.sort();
+    const sortedIndices = selectedElementIndices.sort(function(a,b) {
+      return a - b;
+    });
     const dropIndex = this.findDropIndex(selectedElements, element);
 
     while (sortedIndices.length > 0) {


### PR DESCRIPTION
sort function will order the elements alphabetically:

`
var numArray = [140000, 104, 99];
numArray = numArray.sort();
console.log(numArray)
`

while what we need is:
`
var numArray = [140000, 104, 99];
numArray = numArray.sort(function(a,b) { return a-b;});
console.log(numArray)
`
